### PR TITLE
Add compats

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,3 +14,4 @@ test = ["Test"]
 
 [compat]
 julia = "1"
+Primes = "0.4, 0.5"


### PR DESCRIPTION
@tobydriscoll thank you for the package!

Could we add compat entries and make a release, please?

Currently, HaltonSequences v0.1.1 doesn't allow compatibility with Primes v0.5